### PR TITLE
make contrast method accept strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -497,6 +497,10 @@ proto.opaquer = proto.fadein;
  */
 Object.keys(measure).forEach(function (name) {
 	proto[name] = function (a, b) {
+		
+		// allow color.contrast() to take string args like 'red'
+		if (a && !(a instanceof Color)) a = Color(a)
+
 		return measure[name](this, a, b);
 	};
 });


### PR DESCRIPTION
Hi @dfcreative. 👋 

Thanks for writing `color2`. I am using it in [`make-color-accessible`](https://github.com/zeke/make-color-accessible), a work in progress module for finding colors that meet WCAG contrast guidelines.

Anyhow, about this PR. Currently the `contrast()` method requires a `Color` instance as its argument. This PR makes it possible to also accept input like `blue` or `#336699` without blowing up.

```
$ npm i -g trymodule && trymodule color2=Color
```

```
> Color('white').contrast('black')
TypeError: color.red is not a function
...

> Color('white').contrast('#336699')
TypeError: color.red is not a function
...

> Color('white').contrast(Color('red'))
3.9984767707539985
```